### PR TITLE
Create more test scenarios to the new interfaces

### DIFF
--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -19,7 +19,6 @@ package jakarta.data.metamodel;
 
 import jakarta.data.BasicRestriction;
 import jakarta.data.Operator;
-import jakarta.data.Restrict;
 import jakarta.data.Restriction;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AttributeTest {
+
+}

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -17,8 +17,115 @@
  */
 package jakarta.data.metamodel;
 
-import static org.junit.jupiter.api.Assertions.*;
+import jakarta.data.BasicRestriction;
+import jakarta.data.Operator;
+import jakarta.data.Restrict;
+import jakarta.data.Restriction;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AttributeTest {
 
+    private final Attribute<String> testAttribute = () -> "testAttribute";
+    @Test
+    void shouldCreateEqualToRestriction() {
+        Restriction<String> restriction = testAttribute.equalTo("testValue");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isEqualTo("testValue");
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.EQUAL);
+            soft.assertThat(basic.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateNotEqualToRestriction() {
+        Restriction<String> restriction = testAttribute.notEqualTo("testValue");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isEqualTo("testValue");
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.EQUAL);
+            soft.assertThat(basic.isNegated()).isTrue();
+        });
+    }
+
+    @Test
+    void shouldCreateInRestriction() {
+        Restriction<String> restriction = testAttribute.in("value1", "value2");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isEqualTo(Set.of("value1", "value2"));
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.IN);
+            soft.assertThat(basic.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldThrowExceptionForEmptyInRestriction() {
+        assertThatThrownBy(() -> testAttribute.in())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("values are required");
+    }
+
+    @Test
+    void shouldCreateNotInRestriction() {
+        Restriction<String> restriction = testAttribute.notIn("value1", "value2");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isEqualTo(Set.of("value1", "value2"));
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.IN);
+            soft.assertThat(basic.isNegated()).isTrue();
+        });
+    }
+
+    @Test
+    void shouldThrowExceptionForEmptyNotInRestriction() {
+        assertThatThrownBy(() -> testAttribute.notIn())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("values are required");
+    }
+
+    @Test
+    void shouldCreateIsNullRestriction() {
+        Restriction<String> restriction = testAttribute.isNull();
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isNull();
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.EQUAL);
+            soft.assertThat(basic.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateNotNullRestriction() {
+        Restriction<String> restriction = testAttribute.notNull();
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isNull();
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.EQUAL);
+            soft.assertThat(basic.isNegated()).isTrue();
+        });
+    }
 }

--- a/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
@@ -17,8 +17,116 @@
  */
 package jakarta.data.metamodel;
 
-import static org.junit.jupiter.api.Assertions.*;
+import jakarta.data.BasicRestriction;
+import jakarta.data.CompositeRestriction;
+import jakarta.data.Operator;
+import jakarta.data.Restriction;
+import jakarta.data.Sort;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
 
 class SortableAttributeTest {
 
+    //it ignores the implementation of the SortableAttribute interface and uses an anonymous class to test the methods
+    private final SortableAttribute<String> testAttribute = new SortableAttribute<String>() {
+        @Override
+        public Sort<String> asc() {
+           throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Sort<String> desc() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public String name() {
+            return "testAttribute";
+        }
+    };
+
+    @Test
+    void shouldCreateGreaterThanRestriction() {
+        Restriction<String> restriction = testAttribute.greaterThan(10);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isEqualTo(10);
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.GREATER_THAN);
+            soft.assertThat(basic.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateGreaterThanEqualRestriction() {
+        Restriction<String> restriction = testAttribute.greaterThanEqual(10);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isEqualTo(10);
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.GREATER_THAN_EQUAL);
+            soft.assertThat(basic.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateLessThanRestriction() {
+        Restriction<String> restriction = testAttribute.lessThan(10);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isEqualTo(10);
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.LESS_THAN);
+            soft.assertThat(basic.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateLessThanOrEqualRestriction() {
+        Restriction<String> restriction = testAttribute.lessThanEqual(10);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.value()).isEqualTo(10);
+            soft.assertThat(basic.comparison()).isEqualTo(Operator.LESS_THAN_EQUAL);
+            soft.assertThat(basic.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateBetweenRestriction() {
+        Restriction<String> restriction = testAttribute.between(5, 15);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction).isInstanceOf(CompositeRestriction.class);
+            CompositeRestriction<String> composite = (CompositeRestriction<String>) restriction;
+            soft.assertThat(composite.type()).isEqualTo(CompositeRestriction.Type.ALL);
+            soft.assertThat(composite.restrictions()).hasSize(2);
+
+            Restriction<String> lowerBound = composite.restrictions().get(0);
+            soft.assertThat(lowerBound).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> lower = (BasicRestriction<String>) lowerBound;
+            soft.assertThat(lower.field()).isEqualTo("testAttribute");
+            soft.assertThat(lower.value()).isEqualTo(5);
+            soft.assertThat(lower.comparison()).isEqualTo(Operator.GREATER_THAN_EQUAL);
+            soft.assertThat(lower.isNegated()).isFalse();
+
+            Restriction<String> upperBound = composite.restrictions().get(1);
+            soft.assertThat(upperBound).isInstanceOf(BasicRestriction.class);
+            BasicRestriction<String> upper = (BasicRestriction<String>) upperBound;
+            soft.assertThat(upper.field()).isEqualTo("testAttribute");
+            soft.assertThat(upper.value()).isEqualTo(15);
+            soft.assertThat(upper.comparison()).isEqualTo(Operator.LESS_THAN_EQUAL);
+            soft.assertThat(upper.isNegated()).isFalse();
+        });
+    }
 }

--- a/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SortableAttributeTest {
+
+}

--- a/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
@@ -32,12 +32,12 @@ class SortableAttributeTest {
     private final SortableAttribute<String> testAttribute = new SortableAttribute<String>() {
         @Override
         public Sort<String> asc() {
-           throw new UnsupportedOperationException("Not supported yet.");
+           throw new UnsupportedOperationException("It is not the focus of this test");
         }
 
         @Override
         public Sort<String> desc() {
-            throw new UnsupportedOperationException("Not supported yet.");
+            throw new UnsupportedOperationException("It is not the focus of this test");
         }
 
         @Override

--- a/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TextAttributeTest {
+
+}

--- a/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
@@ -17,8 +17,135 @@
  */
 package jakarta.data.metamodel;
 
-import static org.junit.jupiter.api.Assertions.*;
+import jakarta.data.Operator;
+import jakarta.data.Sort;
+import jakarta.data.TextRestriction;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
 
 class TextAttributeTest {
 
+
+    private final TextAttribute<String> testAttribute = new TextAttribute<String>() {
+        @Override
+        public Sort<String> ascIgnoreCase() {
+            throw new UnsupportedOperationException("Not the focus of this test.");
+        }
+
+        @Override
+        public Sort<String> descIgnoreCase() {
+            throw new UnsupportedOperationException("Not the focus of this test.");
+        }
+
+        @Override
+        public Sort<String> asc() {
+            throw new UnsupportedOperationException("Not the focus of this test.");
+        }
+
+        @Override
+        public Sort<String> desc() {
+            throw new UnsupportedOperationException("Not the focus of this test.");
+        }
+
+        @Override
+        public String name() {
+            return "testAttribute";
+        }
+    };
+
+    @Test
+    void shouldCreateContainsRestriction() {
+        TextRestriction<String> restriction = testAttribute.contains("testValue");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.value()).isEqualTo("%testValue%");
+            soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
+            soft.assertThat(restriction.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateStartsWithRestriction() {
+        TextRestriction<String> restriction = testAttribute.startsWith("testValue");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.value()).isEqualTo("testValue%");
+            soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
+            soft.assertThat(restriction.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateEndsWithRestriction() {
+        TextRestriction<String> restriction = testAttribute.endsWith("testValue");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.value()).isEqualTo("%testValue");
+            soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
+            soft.assertThat(restriction.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateLikeRestriction() {
+        TextRestriction<String> restriction = testAttribute.like("%test%");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.value()).isEqualTo("%test%");
+            soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
+            soft.assertThat(restriction.isNegated()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldCreateNotContainsRestriction() {
+        TextRestriction<String> restriction = testAttribute.notContains("testValue");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.value()).isEqualTo("%testValue%");
+            soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
+            soft.assertThat(restriction.isNegated()).isTrue();
+        });
+    }
+
+    @Test
+    void shouldCreateNotLikeRestriction() {
+        TextRestriction<String> restriction = testAttribute.notLike("%test%");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.value()).isEqualTo("%test%");
+            soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
+            soft.assertThat(restriction.isNegated()).isTrue();
+        });
+    }
+
+    @Test
+    void shouldCreateNotStartsWithRestriction() {
+        TextRestriction<String> restriction = testAttribute.notStartsWith("testValue");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.value()).isEqualTo("testValue%");
+            soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
+            soft.assertThat(restriction.isNegated()).isTrue();
+        });
+    }
+
+    @Test
+    void shouldCreateNotEndsWithRestriction() {
+        TextRestriction<String> restriction = testAttribute.notEndsWith("testValue");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.value()).isEqualTo("%testValue");
+            soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
+            soft.assertThat(restriction.isNegated()).isTrue();
+        });
+    }
 }


### PR DESCRIPTION
This pull request includes the addition of new test classes for the `jakarta.data.metamodel` package. The changes focus on testing various attribute restrictions and sorting functionalities. The most important changes include adding new test cases for `Attribute`, `SortableAttribute`, and `TextAttribute` classes to ensure they handle different restriction scenarios correctly.

I am ignoring the implementable methods and focusing only on the default one.